### PR TITLE
Fix link syntax

### DIFF
--- a/docs/unity-sdk-evm.md
+++ b/docs/unity-sdk-evm.md
@@ -4,7 +4,7 @@ title: EVM-based Smart Contract Quickstart
 sidebar_label: EVM-based Smart Contract Quickstart
 ---
 
-Loom supports EVM ([Ethereum Virtual Machine](evm.html)) and plugin-based smart contracts. Plugin-based smart contracts can be created with (go-loom)[https://github.com/loomnetwork/go-loom], for example.
+Loom supports EVM ([Ethereum Virtual Machine](evm.html)) and plugin-based smart contracts. Plugin-based smart contracts can be created with [go-loom](https://github.com/loomnetwork/go-loom), for example.
 
 In this example, we will demostrate how to use the Unity SDK to communicate with EVM-based smart contracts.
 

--- a/docs/unity-sdk-plugin.md
+++ b/docs/unity-sdk-plugin.md
@@ -5,7 +5,7 @@ sidebar_label: Plugin-based Smart Contract Quickstart
 ---
 
 
-Loom supports EVM ([Ethereum Virtual Machine](evm.html)) and plugin-based smart contracts. Plugin-based smart contracts can be created with (go-loom)[https://github.com/loomnetwork/go-loom], for example.
+Loom supports EVM ([Ethereum Virtual Machine](evm.html)) and plugin-based smart contracts. Plugin-based smart contracts can be created with [go-loom](https://github.com/loomnetwork/go-loom), for example.
 
 In this example, we will demostrate how to use the Unity SDK to communicate with plugin-based smart contracts.
 


### PR DESCRIPTION
The `go-loom` GitHub link on the "Plugin-based Smart Contract Quickstart" page is not proper Markdown so isn't being rendered correctly. This change fixes that.