### PR TITLE
Update Rinkeby gateway address

### DIFF
--- a/docs/testnets-plasma.md
+++ b/docs/testnets-plasma.md
@@ -26,7 +26,7 @@ Where is the Ethereum contract related to a network deployed
 
 Name           | Ethereum Link | TransferGateway Address
 -------------  | ------------- | ------------------------
-Staging Plasma | Rinkeby       | 0x6f7Eb868b2236638c563af71612c9701AC30A388
+Staging Plasma | Rinkeby       | 0xF19D543f5ca6974b8b9b39Fcb923286dE4e9D975
 Plasma Chain   | Mainnet       | n/a 
 Validator Test | Rinkeby       | n/a
 


### PR DESCRIPTION
Current gateway address for Rinkeby gateway is outdated  
according to https://github.com/loomnetwork/truffle-dappchain-example/commit/f24088e6c32723cdbca55a5f4932648ca3f88a1d  
current address is 0xF19D543f5ca6974b8b9b39Fcb923286dE4e9D975
