### PR TITLE
Update broken links to mainnet block explorer

### DIFF
--- a/docs/en/dapp-metrics-website-info.md
+++ b/docs/en/dapp-metrics-website-info.md
@@ -10,8 +10,8 @@ This guide shows how to get useful information on the DApps running on Loom Main
 
 ## Block Explorers
 
-- [MainNet Block Explorer](http://plasma-blockexplorer.dappchains.com/)
-- [TestNet Block Explorer](http://extdev-blockexplorer.dappchains.com)
+- [MainNet Block Explorer](https://basechain-blockexplorer.dappchains.com/)
+- [TestNet Block Explorer](https://extdev-blockexplorer.dappchains.com)
 
 
 ## Overview

--- a/docs/en/how-to-get-contracts-verified.md
+++ b/docs/en/how-to-get-contracts-verified.md
@@ -206,7 +206,7 @@ truffle migrate -f 5 --to 5 --network extdev
 
 ## Verifying the Smart Contract on the Block Explorer
 
-To verify the smart contract, point your web browser to the [Extdev Block Explorer](http://extdev-blockexplorer.dappchains.com/) and type the address of the newly deployed smart contract in the search box.
+To verify the smart contract, point your web browser to the [Extdev Block Explorer](https://extdev-blockexplorer.dappchains.com/) and type the address of the newly deployed smart contract in the search box.
 
 Next, you should see a page similar to the one below:
 

--- a/docs/ja/dapp-metrics-website-info.md
+++ b/docs/ja/dapp-metrics-website-info.md
@@ -10,8 +10,8 @@ This guide shows how to get useful information on the DApps running on Loom Main
 
 ## Block Explorers
 
-- [MainNet Block Explorer](http://plasma-blockexplorer.dappchains.com/)
-- [TestNet Block Explorer](http://extdev-blockexplorer.dappchains.com)
+- [MainNet Block Explorer](https://basechain-blockexplorer.dappchains.com/)
+- [TestNet Block Explorer](https://extdev-blockexplorer.dappchains.com)
 
 ## Web3 Endpoints
 

--- a/docs/ja/how-to-get-contracts-verified.md
+++ b/docs/ja/how-to-get-contracts-verified.md
@@ -206,7 +206,7 @@ truffle migrate -f 5 --to 5 --network extdev
 
 ## Verifying the Smart Contract on the Block Explorer
 
-To verify the smart contract, point your web browser to the [Extdev Block Explorer](http://extdev-blockexplorer.dappchains.com/) and type the address of the newly deployed smart contract in the search box.
+To verify the smart contract, point your web browser to the [Extdev Block Explorer](https://extdev-blockexplorer.dappchains.com/) and type the address of the newly deployed smart contract in the search box.
 
 Next, you should see a page similar to the one below:
 

--- a/docs/ko/dapp-metrics-website-info.md
+++ b/docs/ko/dapp-metrics-website-info.md
@@ -10,8 +10,8 @@ This guide shows how to get useful information on the DApps running on Loom Main
 
 ## Block Explorers
 
-- [MainNet Block Explorer](http://plasma-blockexplorer.dappchains.com/)
-- [TestNet Block Explorer](http://extdev-blockexplorer.dappchains.com)
+- [MainNet Block Explorer](https://basechain-blockexplorer.dappchains.com/)
+- [TestNet Block Explorer](https://extdev-blockexplorer.dappchains.com)
 
 ## Web3 Endpoints
 

--- a/docs/ko/how-to-get-contracts-verified.md
+++ b/docs/ko/how-to-get-contracts-verified.md
@@ -206,7 +206,7 @@ truffle migrate -f 5 --to 5 --network extdev
 
 ## Verifying the Smart Contract on the Block Explorer
 
-To verify the smart contract, point your web browser to the [Extdev Block Explorer](http://extdev-blockexplorer.dappchains.com/) and type the address of the newly deployed smart contract in the search box.
+To verify the smart contract, point your web browser to the [Extdev Block Explorer](https://extdev-blockexplorer.dappchains.com/) and type the address of the newly deployed smart contract in the search box.
 
 Next, you should see a page similar to the one below:
 

--- a/docs/zh-CN/dapp-metrics-website-info.md
+++ b/docs/zh-CN/dapp-metrics-website-info.md
@@ -12,8 +12,8 @@ This guide shows how to get useful information on the DApps running on Loom Main
 
 ## Block Explorers
 
-- [MainNet Block Explorer](http://plasma-blockexplorer.dappchains.com/)
-- [TestNet Block Explorer](http://extdev-blockexplorer.dappchains.com)
+- [MainNet Block Explorer](https://basechain-blockexplorer.dappchains.com/)
+- [TestNet Block Explorer](https://extdev-blockexplorer.dappchains.com)
 
 ## Web3 Endpoints
 

--- a/docs/zh-CN/how-to-get-contracts-verified.md
+++ b/docs/zh-CN/how-to-get-contracts-verified.md
@@ -206,7 +206,7 @@ truffle migrate -f 5 --to 5 --network extdev
 
 ## Verifying the Smart Contract on the Block Explorer
 
-To verify the smart contract, point your web browser to the [Extdev Block Explorer](http://extdev-blockexplorer.dappchains.com/) and type the address of the newly deployed smart contract in the search box.
+To verify the smart contract, point your web browser to the [Extdev Block Explorer](https://extdev-blockexplorer.dappchains.com/) and type the address of the newly deployed smart contract in the search box.
 
 Next, you should see a page similar to the one below:
 


### PR DESCRIPTION
@enlight Please review when you get a chance.

This fixes a few broken links (`plasma-blockexplorer.dappchains.com` -> basechain-blockexplorer.dappchains.com/) and uses `https` instead of `http`.
